### PR TITLE
Fix XML tag naming

### DIFF
--- a/python/tHome/eagle/parse.py
+++ b/python/tHome/eagle/parse.py
@@ -13,7 +13,7 @@ from . import messages
 # </rainForest>
 def parse( xmlText ):
    root = ET.fromstring( xmlText )
-   assert( root.tag == "rainForest" )
+   assert( root.tag == "rainforest" )
 
    child = root[0]
 


### PR DESCRIPTION
rainForest causes an assertion failure...xmltag (via tcpdump) is rainforest